### PR TITLE
boomer: Use Primary planes instead of overlays

### DIFF
--- a/boomer/src/main.rs
+++ b/boomer/src/main.rs
@@ -61,7 +61,7 @@ fn find_mode_for_connector(connector: &Rc<Connector>) -> io::Result<Mode> {
 fn find_plane_for_output(output: &Output) -> Option<Rc<Plane>> {
     output.planes().into_iter().find(|plane| {
         plane.formats().any(|fmt| fmt == Format::XRGB8888)
-            && plane.plane_type() == PlaneType::Overlay
+            && plane.plane_type() == PlaneType::Primary
     })
 }
 


### PR DESCRIPTION
Some platforms might not have overlays, and the reason we initially went for overlays isnt' obvious.

Let's switch to primary planes which are the most obvious choice, and will work on any platform.