### PR TITLE
dradis: Only access the memory actually used

### DIFF
--- a/dradis/src/main.rs
+++ b/dradis/src/main.rs
@@ -469,7 +469,13 @@ fn test_run(
         let buf = &buffers[idx as usize];
         debug_span!("Frame Processing").in_scope(|| {
             if let Ok(metadata) = buf.read(
-                |b, a| decode_and_check_frame(b, a.expect("Missing arguments")).map_err(Into::into),
+                |b, a| {
+                    decode_and_check_frame(
+                        &b[..(vbuf.bytesused as usize)],
+                        a.expect("Missing arguments"),
+                    )
+                    .map_err(Into::into)
+                },
                 Some(DecodeCheckArgs {
                     sequence: vbuf.sequence,
                     previous_frame_idx: last_frame_index,


### PR DESCRIPTION
So far, we were accessing the entire buffer content, even if the driver filled only a portion of it.

We should only access what v4l2_buffer::bytesperused describes. We still assume that we don't have a stride larger than lenght * depth, but I guess we can figure it out later if we ever encounter that case.