### PR TITLE
dradis: Reset pixel format bytes per line

### DIFF
--- a/dradis/src/main.rs
+++ b/dradis/src/main.rs
@@ -252,6 +252,9 @@ fn test_prepare_queue(
             .set_width(test.expected_width)
             .set_height(test.expected_height)
             .set_pixel_format(v4l2_pix_fmt::V4L2_PIX_FMT_RGB24)
+            // From v4l2-ctl: "G_FMT might return a bytesperline value > width, reset this to 0 to
+            // force the driver to update it to the closest value for the new width".
+            .set_bytes_per_line(0)
             .set_field(v4l2_field::V4L2_FIELD_NONE)
     } else {
         unreachable!()

--- a/v4l2-raw/src/wrapper.rs
+++ b/v4l2-raw/src/wrapper.rs
@@ -128,6 +128,13 @@ impl v4l2_pix_format {
         self.pixelformat
     }
 
+    /// Sets the image bytes per line.
+    #[must_use]
+    pub fn set_bytes_per_line(mut self, bytesperline: u32) -> Self {
+        self.bytesperline = bytesperline;
+        self
+    }
+
     /// Sets the image colorspace.
     ///
     /// This function is only effective for output streams. The colorspace will be ignored and set


### PR DESCRIPTION
If not set to 0, in my device (Raspberry Pi 5) this value was not set correctly.

The fix was discovered inspecting the v4l2-ctl source code:
https://github.com/gjasny/v4l-utils/blob/master/utils/v4l2-ctl/v4l2-ctl-vidcap.cpp#L220