### PR TITLE
dradis: Fix clippy error

### DIFF
--- a/dradis/src/helpers.rs
+++ b/dradis/src/helpers.rs
@@ -224,7 +224,7 @@ pub(crate) fn bridge_set_edid(
     )))?;
 
     let mode_vfreq_hz = mode_hfreq_hz
-        / u32::from(u16::from(dtd.vfp) + dtd.vdisplay + u16::from(dtd.vbp) + u16::from(dtd.vsync));
+        / u32::from(u16::from(dtd.vfp) + dtd.vdisplay + dtd.vbp + u16::from(dtd.vsync));
     let min_vfreq_hz = round_down(min(mode_vfreq_hz, VIC_1_VFREQ_HZ), VFREQ_TOLERANCE_HZ)
         .to_u8()
         .ok_or(SetupError::Value(String::from(


### PR DESCRIPTION
`dtd.vbp` is a u16 now and clippy throws this error:

```
   error: useless conversion to the same type: `u16`
      --> dradis/src/helpers.rs:227:57
       |
   227 |  / u32::from(u16::from(dtd.vfp) + dtd.vdisplay
       |  + u16::from(dtd.vbp) + u16::from(dtd.vsync));
       |    ^^^^^^^^^^ help: consider removing `u16::from()`: `dtd.vbp`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
```

Fixes: 11431b75ff5c ("build(deps): bump redid from `4e966cc` to `862de87`")