### PR TITLE
device-info: Add device information

### DIFF
--- a/docs/device-info.md
+++ b/docs/device-info.md
@@ -1,0 +1,35 @@
+# Device Information
+
+## About
+
+The `device-info` directory contains useful information for debugging devices
+that the project developers might not have access to.
+
+## Structure
+
+The information is organized in subdirectories with the following structure:
+
+```
+device-info
+└── <device-name>+<bridge-vendor>-<bridge-model>
+    ├── media-ctl-topology.txt
+    └── urls.txt
+```
+
+For example, information about a Raspberry Pi 5 featuring a GeekWorm C779 HDIM
+to CSI-2 bridge would be stored in `raspberrypi5+geekworm-c779`.
+
+## Files
+
+### `media-ctl-topology.txt`
+
+This file contains information about the media controller topology.
+To generate it, run:
+
+```bash
+$ media-ctl -p > media-ctl-topology.txt
+```
+
+### `urls.txt`
+
+This file contains a list of URLs with relevant information about the bridge.

--- a/docs/device-info/raspberrypi5+geekworm-c779/media-ctl-topology.txt
+++ b/docs/device-info/raspberrypi5+geekworm-c779/media-ctl-topology.txt
@@ -1,0 +1,119 @@
+Media controller API version 6.12.25
+
+Media device information
+------------------------
+driver          rp1-cfe
+model           rp1-cfe
+serial          
+bus info        platform:1f00128000.csi
+hw revision     0x114666
+driver version  6.12.25
+
+Device topology
+- entity 1: csi2 (8 pads, 8 links)
+            type V4L2 subdev subtype Unknown flags 0
+            device node name /dev/v4l-subdev0
+	pad0: Sink
+		[fmt:RGB888_1X24/1280x720 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+		<- "tc358743 11-000f":0 [ENABLED,IMMUTABLE]
+	pad1: Sink
+		[fmt:unknown/16384x1 field:none]
+	pad2: Sink
+		[fmt:SRGGB10_1X10/640x480 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+	pad3: Sink
+		[fmt:SRGGB10_1X10/640x480 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+	pad4: Source
+		[fmt:RGB888_1X24/1280x720 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+		-> "rp1-cfe-csi2_ch0":0 []
+		-> "pisp-fe":0 []
+	pad5: Source
+		[fmt:unknown/16384x1 field:none]
+		-> "rp1-cfe-embedded":0 []
+	pad6: Source
+		[fmt:SRGGB10_1X10/640x480 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+		-> "rp1-cfe-csi2_ch2":0 []
+		-> "pisp-fe":0 []
+	pad7: Source
+		[fmt:SRGGB10_1X10/640x480 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+		-> "rp1-cfe-csi2_ch3":0 []
+		-> "pisp-fe":0 []
+
+- entity 10: pisp-fe (5 pads, 7 links)
+             type V4L2 subdev subtype Unknown flags 0
+             device node name /dev/v4l-subdev1
+	pad0: Sink
+		[fmt:SRGGB16_1X16/640x480 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+		<- "csi2":4 []
+		<- "csi2":6 []
+		<- "csi2":7 []
+	pad1: Sink
+		[fmt:FIXED/16384x1 field:none]
+		<- "rp1-cfe-fe_config":0 []
+	pad2: Source
+		[fmt:SRGGB16_1X16/640x480 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+		-> "rp1-cfe-fe_image0":0 []
+	pad3: Source
+		[fmt:SRGGB16_1X16/640x480 field:none colorspace:raw xfer:none ycbcr:601 quantization:full-range]
+		-> "rp1-cfe-fe_image1":0 []
+	pad4: Source
+		[fmt:FIXED/16384x1 field:none]
+		-> "rp1-cfe-fe_stats":0 []
+
+- entity 16: tc358743 11-000f (1 pad, 1 link)
+             type V4L2 subdev subtype Unknown flags 0
+             device node name /dev/v4l-subdev2
+	pad0: Source
+		[fmt:RGB888_1X24/1280x720 field:none colorspace:srgb]
+		[dv.caps:BT.656/1120 min:640x350@13000000 max:1920x1200@165000000 stds:CEA-861,DMT,CVT,GTF caps:progressive,reduced-blanking,custom]
+		[dv.detect:BT.656/1120 1280x720p60 (1650x750) stds: flags:]
+		[dv.current:BT.656/1120 1280x720p60 (1650x750) stds: flags:]
+		-> "csi2":0 [ENABLED,IMMUTABLE]
+
+- entity 18: rp1-cfe-csi2_ch0 (1 pad, 1 link)
+             type Node subtype V4L flags 0
+             device node name /dev/video0
+	pad0: Sink
+		<- "csi2":4 []
+
+- entity 22: rp1-cfe-embedded (1 pad, 1 link)
+             type Node subtype V4L flags 0
+             device node name /dev/video1
+	pad0: Sink
+		<- "csi2":5 []
+
+- entity 26: rp1-cfe-csi2_ch2 (1 pad, 1 link)
+             type Node subtype V4L flags 0
+             device node name /dev/video2
+	pad0: Sink
+		<- "csi2":6 []
+
+- entity 30: rp1-cfe-csi2_ch3 (1 pad, 1 link)
+             type Node subtype V4L flags 0
+             device node name /dev/video3
+	pad0: Sink
+		<- "csi2":7 []
+
+- entity 34: rp1-cfe-fe_image0 (1 pad, 1 link)
+             type Node subtype V4L flags 1
+             device node name /dev/video4
+	pad0: Sink
+		<- "pisp-fe":2 []
+
+- entity 38: rp1-cfe-fe_image1 (1 pad, 1 link)
+             type Node subtype V4L flags 0
+             device node name /dev/video5
+	pad0: Sink
+		<- "pisp-fe":3 []
+
+- entity 42: rp1-cfe-fe_stats (1 pad, 1 link)
+             type Node subtype V4L flags 0
+             device node name /dev/video6
+	pad0: Sink
+		<- "pisp-fe":4 []
+
+- entity 46: rp1-cfe-fe_config (1 pad, 1 link)
+             type Node subtype V4L flags 0
+             device node name /dev/video7
+	pad0: Source
+		-> "pisp-fe":1 []
+

--- a/docs/device-info/raspberrypi5+geekworm-c779/urls.txt
+++ b/docs/device-info/raspberrypi5+geekworm-c779/urls.txt
@@ -1,0 +1,5 @@
+General information about the GeekWorn C779 bridge:
+https://wiki.geekworm.com/C779
+
+Manual configuration for the bridge on the Raspberry Pi 5:
+https://wiki.geekworm.com/CSI_Manual_on_Pi_5


### PR DESCRIPTION
Create a directory containing useful information for debugging devices that the project developers might not have access to.

I don't know if there is any other information that can be useful for debugging now or when a user reports a bug, but I'd be happy to add more info if required.